### PR TITLE
Replaces a few plain text words in mustache file

### DIFF
--- a/src/customer/report.mustache
+++ b/src/customer/report.mustache
@@ -311,7 +311,7 @@ The remainder of this report provides findings and metrics of the CISA phishing 
 
 CISA used the methodology documented in \nameref{sec:Methodology} to perform testing of <<Acronym>>. Specific phishing templates can be reviewed in \nameref{sec:Templates} with their corresponding deception calculations. <<Group_String>> See table 3 for descriptions of email levels 1–6.
 
-The assessment's goal was to capture the behavior-based responses of <<Acronym>> to email phishing attempts; and the assessment operated under the scenario that no technical controls were able to detect, report, or stop the email phishing attempts. CISA, as an external body conducting this PCA, did not have direct knowledge whether or not emails successfully arrived in targeted <<Acronym>> user inboxes. To allow for a clear determination of click rates (email links clicked divided by emails sent), <<Acronym>> or CISA performed the following:
+The assessment's goal was to capture the behavior-based responses of <<Acronym>> to email phishing attempts; and the assessment operated under the scenario that no technical controls were able to detect, report, or stop the email phishing attempts. CISA, as an external body conducting this PCA, did not have direct knowledge whether or not emails successfully arrived in targeted <<Acronym>> user inboxes. To allow for a clear determination of click rates and report rates, <<Acronym>> or CISA performed the following:
 \begin{itemize}
 	<<Customer_Setup>>
 \end{itemize}


### PR DESCRIPTION
Replaces a few plain text words in mustache file

## 🗣 Description ##

Replacement made at report.mustache line 314 from “(email links clicked divided by emails sent)” to “and report rates”. PCDEV-107 request from Kelly Thiele.

## 💭 Motivation and context ##

Not a code change. This will update the mustache file's text with a couple new words.

## 🧪 Testing ##

N/A

## 📷 Screenshots (if appropriate) ##

N/A

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
