### PR TITLE
Typo- added a space between two words

### DIFF
--- a/src/customer/report.mustache
+++ b/src/customer/report.mustache
@@ -203,7 +203,7 @@
 \textbf{Dates}
 	&  <<Start_Date>> to <<End_Date>> \\
 \textbf{Test Location}
-	&CISAAssessments Lab, Arlington, VA\\
+	&CISA Assessments Lab, Arlington, VA\\
 \textbf{Scope}
 	&<<Num_Users>> users within the following domain:
 	\newline % Sets new line for domains.


### PR DESCRIPTION
Typo- added a space between two words

## 🗣 Description ##

An extra space made at report.mustache line 206 from "CISAAssessments" to "CISA Assessments".
PCADEV-102 requested by Kelly Thiele.

## 💭 Motivation and context ##

Not a code change. This will update the mustache file's text by fixing a typo.

## 🧪 Testing ##

N/A

## 📷 Screenshots (if appropriate) ##

N/A

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.