### PR TITLE
Added two page breaks

### DIFF
--- a/src/customer/report.mustache
+++ b/src/customer/report.mustache
@@ -897,7 +897,7 @@ Figure~\ref{fig:UniqueTotalClickReportResultsByLevel} shows the comparison of un
 	\caption{Unique click, total click, and report results by level\label{fig:UniqueTotalClickReportResultsByLevel}}
 \end{figure}
 
-Figure~\ref{fig:BreakdownMultipleClicksByLevel} shows the number of users who clicked once, 2–3 times, 4–5 times, 6–10 times, and more than 10 times per campaign, broken down by deception level. Users who click more than once are creating multiple connect-and-control opportunities for the adversary.
+\pagebreak Figure~\ref{fig:BreakdownMultipleClicksByLevel} shows the number of users who clicked once, 2–3 times, 4–5 times, 6–10 times, and more than 10 times per campaign, broken down by deception level. Users who click more than once are creating multiple connect-and-control opportunities for the adversary.
 
 \begin{figure}[H]
 	\includegraphics[width=\textwidth,height=\textheight,keepaspectratio]{figures/BreakdownMultipleClicksByLevel}
@@ -981,7 +981,7 @@ Table~\ref{tab:EventLog} shows the time-related event log throughout testing.
 	}
 \end{table}
 
-Figure~\ref{fig:ClickingUserTimeline} shows the percentage of clicking users who had clicked by certain time intervals for each of the six deception levels.
+\pagebreak Figure~\ref{fig:ClickingUserTimeline} shows the percentage of clicking users who had clicked by certain time intervals for each of the six deception levels.
 
 \begin{figure}[H]
 	\includegraphics[width=\textwidth,height=\textheight,keepaspectratio]{figures/ClickingUserTimeline}


### PR DESCRIPTION
Added two page breaks keywords

## 🗣 Description ##

Added the keyword "\pagebreak" to the beginning of line 900 and line 984. PCADEV-110 requested by Laura Hodsden.

## 💭 Motivation and context ##

Not a code change. This will update the mustache file's text with two page break keywords. 

## 🧪 Testing ##

N/A

## 📷 Screenshots (if appropriate) ##

N/A

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.