### PR TITLE
Add table lines in latex format in mustache file

### DIFF
--- a/src/customer/report.mustache
+++ b/src/customer/report.mustache
@@ -1629,9 +1629,11 @@ Below are the details about the templates used during PCA with <<Acronym>>. The 
 	\textbf{Total emails sent:} & <<Level-1-Emails_Sent_Attempted>> \\
 	\textbf{Unique targets who clicked:} & <<Level-1-User_Clicks>> \\
 	\textbf{Unique click rate:} & <<Level-1-Click_Rate>>\% \\
+	\textbf{CISA average click rate for level:} & 4.4\% \\
 	\textbf{Total clicks:} & <<Level-1-Total_Clicks>> \\
 	\textbf{Total user reports:} & <<Level-1-User_Reports>>\\
 	\textbf{Report rate:} & <<Level-1-Report-Rate>>\% \\
+	\textbf{CISA average report rate for level:} & 6.2\% \\
 \end{tabular}
 \end{table}
 
@@ -1650,9 +1652,11 @@ Below are the details about the templates used during PCA with <<Acronym>>. The 
 	\textbf{Total emails sent:} & <<Level-2-Emails_Sent_Attempted>> \\
 	\textbf{Unique targets who clicked:} & <<Level-2-User_Clicks>> \\
 	\textbf{Unique click rate:} & <<Level-2-Click_Rate>>\% \\
+	\textbf{CISA average click rate for level:} & 9.5\% \\
 	\textbf{Total clicks:} & <<Level-2-Total_Clicks>> \\
 	\textbf{Total user reports:} & <<Level-2-User_Reports>>\\
 	\textbf{Report rate:} & <<Level-2-Report-Rate>>\% \\
+	\textbf{CISA average report rate for level:} & 5.5\% \\
 \end{tabular}
 \end{table}
 
@@ -1672,9 +1676,11 @@ Below are the details about the templates used during PCA with <<Acronym>>. The 
 	\textbf{Total emails sent:} & <<Level-3-Emails_Sent_Attempted>> \\
 	\textbf{Unique targets who clicked:} & <<Level-3-User_Clicks>> \\
 	\textbf{Unique click rate:} & <<Level-3-Click_Rate>>\% \\
+	\textbf{CISA average click rate for level:} & 7.3\% \\
 	\textbf{Total clicks:} & <<Level-3-Total_Clicks>> \\
 	\textbf{Total user reports:} & <<Level-3-User_Reports>>\\
 	\textbf{Report rate:} & <<Level-3-Report-Rate>>\% \\
+	\textbf{CISA average report rate for level:} & 7.4\% \\
 \end{tabular}
 \end{table}
 
@@ -1693,9 +1699,11 @@ Below are the details about the templates used during PCA with <<Acronym>>. The 
 	\textbf{Total emails sent:} & <<Level-4-Emails_Sent_Attempted>> \\
 	\textbf{Unique targets who clicked:} & <<Level-4-User_Clicks>> \\
 	\textbf{Unique click rate:} & <<Level-4-Click_Rate>>\% \\
+	\textbf{CISA average click rate for level:} & 8.0\% \\
 	\textbf{Total clicks:} & <<Level-4-Total_Clicks>> \\
 	\textbf{Total user reports:} & <<Level-4-User_Reports>>\\
 	\textbf{Report rate:} & <<Level-4-Report-Rate>>\% \\
+	\textbf{CISA average report rate for level:} & 7.9\% \\
 \end{tabular}
 \end{table}
 
@@ -1714,9 +1722,11 @@ Below are the details about the templates used during PCA with <<Acronym>>. The 
 	\textbf{Total emails sent:} & <<Level-5-Emails_Sent_Attempted>> \\
 	\textbf{Unique targets who clicked:} & <<Level-5-User_Clicks>> \\
 	\textbf{Unique click rate:} & <<Level-5-Click_Rate>>\% \\
+	\textbf{CISA average click rate for level:} & 20.6\% \\
 	\textbf{Total clicks:} & <<Level-5-Total_Clicks>> \\
 	\textbf{Total user reports:} & <<Level-5-User_Reports>>\\
 	\textbf{Report rate:} & <<Level-5-Report-Rate>>\% \\
+	\textbf{CISA average report rate for level:} & 7.6\% \\
 \end{tabular}
 \end{table}
 
@@ -1735,9 +1745,11 @@ Below are the details about the templates used during PCA with <<Acronym>>. The 
 	\textbf{Total emails sent:} & <<Level-6-Emails_Sent_Attempted>> \\
 	\textbf{Unique targets who clicked:} & <<Level-6-User_Clicks>> \\
 	\textbf{Unique click rate:} & <<Level-6-Click_Rate>>\% \\
+	\textbf{CISA average click rate for level:} & 19.2\% \\
 	\textbf{Total clicks:} & <<Level-6-Total_Clicks>> \\
 	\textbf{Total user reports:} & <<Level-6-User_Reports>>\\
 	\textbf{Report rate:} & <<Level-6-Report-Rate>>\% \\
+	\textbf{CISA average report rate for level:} & 9.7\% \\
 \end{tabular}
 \end{table}
 

--- a/src/customer/report.mustache
+++ b/src/customer/report.mustache
@@ -1624,6 +1624,7 @@ Below are the details about the templates used during PCA with <<Acronym>>. The 
 \end{center}
 \hangindent1em \textbf{Key characteristics:} <<Level-1-Key_Characteristics>>
 
+%CISA averages rates should be updated yearly with previous year's average rates. Current rates are for 2020.
 \begin{table}[h]
 \begin{tabular}{ll}
 	\textbf{Total emails sent:} & <<Level-1-Emails_Sent_Attempted>> \\

--- a/src/customer/report.mustache
+++ b/src/customer/report.mustache
@@ -1624,7 +1624,8 @@ Below are the details about the templates used during PCA with <<Acronym>>. The 
 \end{center}
 \hangindent1em \textbf{Key characteristics:} <<Level-1-Key_Characteristics>>
 
-%CISA averages rates should be updated yearly with previous year's average rates. Current rates are for 2020.
+% CISA average rates should be updated yearly with previous year's average rates.
+% Current rates are for 2020.
 \begin{table}[h]
 \begin{tabular}{ll}
 	\textbf{Total emails sent:} & <<Level-1-Emails_Sent_Attempted>> \\


### PR DESCRIPTION
Adds hardcoded text into each levels table of the Templates section of Appendix C.

## 🗣 Description ##

“CISA average click rate for level” entry added to lines: 1632, 1655, 1679, 1702, 1725, 1748.
“CISA average report rate for level” entry added to lines: 1636, 1659, 1683, 1706, 1729, 1752. 
PCADEV-111 requested by Kelly Thiele.

## 💭 Motivation and context ##

Not a code change. This will add latex formatted table lines to the mustache file with CISA average click and report rates for each level within the Templates section of Appendix C. 

## 🧪 Testing ##

N/A

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
